### PR TITLE
Add enquiries controller tests

### DIFF
--- a/app/models/enquiry.rb
+++ b/app/models/enquiry.rb
@@ -5,7 +5,7 @@ class Enquiry < ApplicationRecord
   validates :email, format: { with: URI::MailTo::EMAIL_REGEXP } 
   validates :mobile, :presence => true, :numericality => true, :length => { :minimum => 11, :maximum => 15 }
   validates :nights_of_stay, numericality: { greater_than_or_equal_to: 1 }
-  validates_comparison_of :check_out, greater_than: :check_in, other_than: -> { Date.today }
+  validates_comparison_of :check_out, greater_than: :check_in, other_than: ->(_record) { Date.today }
 
   after_create :send_thanks_email, :send_new_enquiry_email
 

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -1,5 +1,7 @@
 class Property < ApplicationRecord
   has_many :enquiries, dependent: :destroy
+  has_many :bookings, dependent: :destroy
+  has_many :recommendations, dependent: :destroy
 
   validates :title, :description, :price_per_night, :minimum_nights, :cleaning_fee, :max_guests, :bedrooms, :bathrooms, :pet_friendly, presence: true
 

--- a/test/controllers/enquiries_controller_test.rb
+++ b/test/controllers/enquiries_controller_test.rb
@@ -1,8 +1,97 @@
 require "test_helper"
 
 class EnquiriesControllerTest < ActionDispatch::IntegrationTest
-  test "should get new" do
-    get enquiries_new_url
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    @property = properties(:one)
+    @enquiry = enquiries(:one)
+    @user = User.create!(email: "test@example.com", password: "password123", password_confirmation: "password123")
+    ActionMailer::Base.deliveries.clear
+  end
+
+  teardown do
+    @user&.destroy
+  end
+
+  # new and create are public
+  test "new is accessible without login" do
+    get property_new_enquiry_path(@property)
     assert_response :success
+  end
+
+  test "create with valid params creates an enquiry and redirects to property" do
+    assert_difference "Enquiry.count", 1 do
+      post property_enquiries_path(@property), params: { enquiry: valid_enquiry_params }
+    end
+    assert_redirected_to property_path(@property)
+  end
+
+  test "create sends two emails on success" do
+    post property_enquiries_path(@property), params: { enquiry: valid_enquiry_params }
+    assert_equal 2, ActionMailer::Base.deliveries.size
+  end
+
+  test "create with invalid params re-renders new" do
+    post property_enquiries_path(@property), params: { enquiry: { first_name: "" } }
+    assert_response :unprocessable_entity
+  end
+
+  test "create with invalid params does not send emails" do
+    post property_enquiries_path(@property), params: { enquiry: { first_name: "" } }
+    assert_empty ActionMailer::Base.deliveries
+  end
+
+  # index, show, destroy require authentication
+  test "index redirects to sign-in when not logged in" do
+    get property_enquiries_path(@property)
+    assert_redirected_to new_user_session_path
+  end
+
+  test "show redirects to sign-in when not logged in" do
+    get property_enquiry_path(@property, @enquiry)
+    assert_redirected_to new_user_session_path
+  end
+
+  test "destroy redirects to sign-in when not logged in" do
+    delete property_enquiry_path(@property, @enquiry)
+    assert_redirected_to new_user_session_path
+  end
+
+  test "index returns success when logged in" do
+    sign_in @user
+    get property_enquiries_path(@property)
+    assert_response :success
+  end
+
+  test "show returns success when logged in" do
+    sign_in @user
+    get property_enquiry_path(@property, @enquiry)
+    assert_response :success
+  end
+
+  test "destroy deletes the enquiry and redirects" do
+    sign_in @user
+    assert_difference "Enquiry.count", -1 do
+      delete property_enquiry_path(@property, @enquiry)
+    end
+    assert_redirected_to property_enquiries_path(property_id: @property.id)
+  end
+
+  private
+
+  def valid_enquiry_params
+    {
+      first_name: "Jane",
+      last_name: "Smith",
+      email: "jane@example.com",
+      mobile: "07700900000",
+      check_in: 7.days.from_now.to_date,
+      check_out: 10.days.from_now.to_date,
+      guests: 2,
+      with_pets: false,
+      message: "Looking forward to it",
+      referral: "Google"
+    }
   end
 end


### PR DESCRIPTION
## Summary

- Adds 11 integration tests for `EnquiriesController` covering all actions (`new`, `create`, `index`, `show`, `destroy`)
- Tests verify public actions are accessible without login, authenticated actions redirect to sign-in when logged out, and correct behaviour when authenticated
- Includes assertions that two emails are sent on successful enquiry creation, and no emails on failed creation

## Bug fixes uncovered by tests

- `Property` model was missing `has_many :bookings` and `has_many :recommendations` — `@property.bookings` in the enquiries controller was raising `NoMethodError`
- `Enquiry` comparison validator used a 0-arity lambda (`-> { Date.today }`) for `other_than`, but Rails calls comparison procs with the record as an argument. Ruby lambdas enforce arity strictly, so this raised `ArgumentError` on every save, silently failing all enquiry submissions. Fixed with `->(_record) { Date.today }`

## Test plan

- [ ] `RBENV_VERSION=3.2.2 bin/rails test test/controllers/enquiries_controller_test.rb` — all 11 tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)